### PR TITLE
This PR will enable Python 2.x and 3.x coexisting just fine

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ This library also read hostname using python native (`socket.gethostname()`).
 
 Service name and hostname can overridden when initialisation Chillog object like example below
 
+You also have option to prettify log or not. Default is False
+
 ```python
 from chillog.logger import Chillog
 
-logger = Chillog(service_name="SERVICE_NAME", hostname="HOSTNAME")
+logger = Chillog(service_name="SERVICE_NAME", hostname="HOSTNAME", prettify_log=True)
 ```
 
 There are 7 logger you can use:

--- a/chillog/logger.py
+++ b/chillog/logger.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 import os
 import socket
@@ -64,7 +65,7 @@ class Chillog:
         :param formatted_log: Formatted JSON log
         :return: Print to stdout
         """
-        print json.dumps(formatted_log, indent=4, sort_keys=True)
+        print(json.dumps(formatted_log, indent=4, sort_keys=True))
 
     def build_log_message(self, log_level, short_message, **kwargs):
         """

--- a/chillog/logger.py
+++ b/chillog/logger.py
@@ -19,7 +19,7 @@ class Chillog:
     LOG_INFO = 6
     LOG_DEBUG = 7
 
-    def __init__(self, service_name=None, hostname=None):
+    def __init__(self, service_name=None, hostname=None, prettify_log=False):
         """
         Init logger
         Just do this one time and reuse object for best practice
@@ -30,6 +30,7 @@ class Chillog:
         """
         self.__service_name = service_name if service_name else os.environ.get('SERVICE_NAME')
         self.__hostname = hostname if hostname else socket.gethostname()
+        self.__prettify_log = prettify_log
 
     @staticmethod
     def __get_current_millis():
@@ -56,15 +57,17 @@ class Chillog:
 
         return dict_to_add
 
-    @staticmethod
-    def __print_log(formatted_log):  # pragma: no cover
+    def __print_log(self, formatted_log):  # pragma: no cover
         """
-        Print formatted log prettify
+        Print formatted log
 
         :param formatted_log: Formatted JSON log
         :return: Print to stdout
         """
-        print json.dumps(formatted_log, indent=4, sort_keys=True)
+        if self.__prettify_log:
+            print json.dumps(formatted_log, indent=4, sort_keys=True)
+        else:
+            print json.dumps(formatted_log, sort_keys=True)
 
     def build_log_message(self, log_level, short_message, **kwargs):
         """

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from distutils.core import setup
 
 setup(
     name='py-chillog',
-    version='0.1',
+    version='0.2',
     description='SFE Custom Logger based on GELF for python',
     author='Rama Bramantara',
-    author_email='rama@onebitmedia.com',
+    author_email='rama@prismapp.io',
     packages=['chillog'],
     license='MIT',
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='py-chillog',
-    version='0.1',
+    version='0.1.1',
     description='SFE Custom Logger based on GELF for python',
     author='Rama Bramantara',
     author_email='rama@onebitmedia.com',


### PR DESCRIPTION
Solved by:

```python
from __future__ import print_function

print('Jangan bagaikan air di daun talas..')
```

The above must be at the top of all imports. `setup.py` version bumped to `0.1.1`.

To solve https://github.com/coralhq/py-chillog/issues/3